### PR TITLE
取消对象转数组

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -45,7 +45,7 @@ class JWT extends AbstractComponent
     /**
      * 获取有效载荷
      * @param $token
-     * @return array
+     * @return mixed
      */
     public function parser($token)
     {

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -51,10 +51,10 @@ class JWT extends AbstractComponent
     {
         switch ($this->algorithm) {
             case self::ALGORITHM_HS256:
-                return (array)\Firebase\JWT\JWT::decode($token, $this->key, ['HS256']);
+                return \Firebase\JWT\JWT::decode($token, $this->key, ['HS256']);
                 break;
             case self::ALGORITHM_RS256:
-                return (array)\Firebase\JWT\JWT::decode($token, $this->publicKey, ['RS256']);
+                return \Firebase\JWT\JWT::decode($token, $this->publicKey, ['RS256']);
                 break;
             default:
                 throw new \InvalidArgumentException('Invalid signature algorithm.');


### PR DESCRIPTION
出于以下几个考虑：
1、如果一开始存入的是多维数组，经此转换会产生既有数组又有对象
2、如果一开始存入的就是对象，被转成数据会令人奇怪
3、如果不考虑修改或继承修改jwt源码中json_decode第二个参数，建议此处不转数组