### PR TITLE
fixed JWT.php

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -46,14 +46,6 @@ class JWT
      */
     public $algorithm = self::ALGORITHM_HS256;
 
-    /**
-     * Authorization constructor.
-     * @param array $config
-     */
-    public function __construct(array $config)
-    {
-        BeanInjector::inject($this, $config);
-    }
 
     /**
      * 解析Token


### PR DESCRIPTION
删除49-56行代码， 因为 BeanDefinition.php 156、157行代码为 
$object or $object = new $class();
BeanInjector::inject($object, $properties);
否则会报参数错误